### PR TITLE
cf workload can support multiple user

### DIFF
--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -27,6 +27,7 @@ var params = struct {
 	workload            string
 	interval            int
 	stop                int
+	cfHomes             string
 	restUser            string
 	restPass            string
 	restTarget          string
@@ -45,6 +46,7 @@ func InitCommandLineFlags(config config.Config) {
 	config.IntVar(&params.stop, "stop", 0, "repeat a repeating interval until n seconds, to be used with -interval")
 	config.BoolVar(&params.listWorkloads, "list-workloads", false, "Lists the available workloads")
 	config.StringVar(&params.restTarget, "rest:target", "", "the target for the REST api")
+	config.StringVar(&params.cfHomes, "cfhomes", "", "cfhome for cli")
 	config.StringVar(&params.restUser, "rest:username", "", "username for REST api")
 	config.StringVar(&params.restPass, "rest:password", "", "password for REST api")
 	config.StringVar(&params.restSpace, "rest:space", "dev", "space to target for REST api")
@@ -58,6 +60,7 @@ func RunCommandLine() error {
 	workloadContext := NewContext()
 	workloads.PopulateRestContext(params.restTarget, params.restUser, params.restPass, params.restSpace, workloadContext)
 	workloads.PopulateAppContext(params.app, params.manifest, workloadContext)
+	workloads.PopulateCliContext(params.cfHomes, workloadContext)
 
 	return WithConfiguredWorkerAndSlaves(func(worker benchmarker.Worker) error {
 		return validateParameters(worker, func() error {

--- a/cmdline/cmdline_test.go
+++ b/cmdline/cmdline_test.go
@@ -84,6 +84,26 @@ var _ = Describe("Cmdline", func() {
 		})
 	})
 
+	Describe("When -cfhomes is supplied", func() {
+		var (
+			ctx context.Context
+		)
+
+		BeforeEach(func() {
+			ctx = context.New()
+			args = []string{"-cfhomes", "somehomes"}
+			NewContext = func() context.Context {
+				return ctx
+			}
+		})
+
+		It("configures the experiment with the parameter", func() {
+			path, ok := ctx.GetString("cfhomes")
+			Ω(ok).To(BeTrue())
+			Ω(path).To(Equal("somehomes"))
+		})
+	})
+
 	Describe("When -app is supplied", func() {
 		var (
 			ctx context.Context

--- a/workloads/workloads.go
+++ b/workloads/workloads.go
@@ -68,6 +68,10 @@ func PopulateAppContext(appPath string, manifestPath string, ctx context.Context
 	return nil
 }
 
+func PopulateCliContext(cfhomes string, ctx context.Context) {
+	ctx.PutString("cfhomes", cfhomes)
+}
+
 func normalizePath(aPath string) (string, error) {
 	if aPath == "" {
 		return "", nil

--- a/workloads/workloads_test.go
+++ b/workloads/workloads_test.go
@@ -78,4 +78,15 @@ var _ = Describe("Workloads", func() {
 		})
 
 	})
+
+	Describe("#PopulateCliContext", func() {
+		It("inserts the cfhomes into the context", func() {
+			ctx := context.New()
+			PopulateCliContext("somehomes", ctx)
+			homePath, ok := ctx.GetString("cfhomes")
+			Ω(Expect(ok).To(BeTrue()))
+			Ω(Expect(homePath).To(Equal("somehomes")))
+
+		})
+	})
 })


### PR DESCRIPTION
- currently there is a limitation "cf workloads assume single
  already-logged-in-and-targetted
  user" in [Known Limitations / TODOs etc.](https://github.com/cloudfoundry-incubator/pat/blob/master/README.md#known-limitations--todos-etc)
- cf cli support different user by CF_HOME
- set cfhomes can achive multi already logged user
- also add the test case for the feature

Signed-off-by: zyw69542 zhouyingwei@huawei.com
