### PR TITLE
display in table view to save screen

### DIFF
--- a/Cartridge
+++ b/Cartridge
@@ -8,3 +8,4 @@ github.com/cloudfoundry/gosteno origin/master
 github.com/onsi/ginkgo origin/master
 github.com/onsi/gomega origin/master
 github.com/go-yaml/yaml origin/master
+github.com/crackcomm/go-clitable origin/master

--- a/Cartridge.lock
+++ b/Cartridge.lock
@@ -8,3 +8,4 @@ github.com/cloudfoundry/gosteno	5eb8c6e554f0dfc39d6468813b8ac19ec28fe74f
 github.com/onsi/ginkgo	32204a3eab0576cbea19f5ff8b27d3a928647ea6
 github.com/onsi/gomega	a78ae492d53aad5a7a232d0d0462c14c400e3ee7
 github.com/go-yaml/yaml	53feefa2559fb8dfa8d81baad31be332c97d6c77
+github.com/crackcomm/go-clitable	8ddbe7cde501fa7e2919965c4c5e628791a8d1a6

--- a/cmdline/cmdline.go
+++ b/cmdline/cmdline.go
@@ -74,7 +74,7 @@ func RunCommandLine() error {
 				handlers := make([]func(<-chan *Sample), 0)
 				if !params.silent {
 					handlers = append(handlers, func(s <-chan *Sample) {
-						display(params.concurrency, params.iterations, params.interval, params.stop, params.concurrencyStepTime, s)
+						display_table(params.concurrency, params.iterations, params.interval, params.stop, params.concurrencyStepTime, s)
 					})
 				}
 


### PR DESCRIPTION
- when too many Commands Issued tree view will take full sreen
- support a table view display to save sreen
- later, we can sort the commands to save sreen from refreshing

Signed-off-by: zyw69542 zhouyingwei@huawei.com
